### PR TITLE
Demonstrate how to call `raw_rand` and pass the result to JavaScript (and back)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "3dff9853339d4a5b75094c8edd65c3a0e81da8281855332d79559ddd8591b236"
 dependencies = [
  "proc-macro2",
 ]
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/canisters/boa/src/lib.rs
+++ b/canisters/boa/src/lib.rs
@@ -12,8 +12,10 @@ async fn rand_bytes() -> String {
         // Pretend that raw_rand takes arguments, for the sake of
         // demonstration.
         rawRand("hello", true, 42, function (randBytes) {
-          // Do something with randBytes. For now just return it.
-          return randBytes;
+          // Do something with randBytes. Since we are converting it to a string
+          // for convenience in this demo, add a prefix message to demonstrate
+          // that we are legitimately going through this JS callback function.
+          return "Random bytes via JS callback: " + randBytes;
         });
     "#).unwrap();
 

--- a/canisters/boa/src/lib.rs
+++ b/canisters/boa/src/lib.rs
@@ -9,8 +9,7 @@ async fn rand_bytes() -> String {
     ).unwrap();
 
     let args = context.eval(r#"
-        // Pretend that raw_rand takes arguments, for the sake of
-        // demonstration.
+        // Pretend that raw_rand takes arguments, for the sake of demonstration.
         rawRand("hello", true, 42, function (randBytes) {
           // Do something with randBytes. Since we are converting it to a string
           // for convenience in this demo, add a prefix message to demonstrate

--- a/canisters/boa/src/lib.rs
+++ b/canisters/boa/src/lib.rs
@@ -9,7 +9,7 @@ async fn rand_bytes() -> String {
     ).unwrap();
 
     let args = context.eval(r#"
-        // Pretend that raw_rand takes an argument, for the sake of
+        // Pretend that raw_rand takes arguments, for the sake of
         // demonstration.
         rawRand("hello", true, 42, function (randBytes) {
           // Do something with randBytes. For now just return it.

--- a/canisters/boa/src/lib.rs
+++ b/canisters/boa/src/lib.rs
@@ -43,7 +43,7 @@ async fn rand_bytes() -> String {
     let value = context
         .eval(
             format!(
-                "Uint8Array.from({rand_bytes})",
+                "Uint8Array.from({rand_bytes}).toString()",
                 rand_bytes = serde_json::to_string(&rand_bytes).unwrap()
             )
         )

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,110 @@
+{
+  "nodes": {
+    "dfinity-sdk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1642883828,
+        "narHash": "sha256-nFCsVldf1ve/hq0rWMbTbNBFcWKjKgrV0Ks1Kf73S+Y=",
+        "owner": "paulyoung",
+        "repo": "nixpkgs-dfinity-sdk",
+        "rev": "cd84db5a5eae1df638df14926db83801cb4263eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "paulyoung",
+        "repo": "nixpkgs-dfinity-sdk",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mozillapkgs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1638887313,
+        "narHash": "sha256-FMYV6rVtvSIfthgC1sK1xugh3y7muoQcvduMdriz4ag=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "7c1e8b1dd6ed0043fb4ee0b12b815256b0b9de6f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1639947939,
+        "narHash": "sha256-pGsM8haJadVP80GFq4xhnSpNitYNQpaXk4cnA796Cso=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1642819963,
+        "narHash": "sha256-pfd+ZKHj88jHtnRbLP/+uj3qNUjrkrQGRp9w3YKDzeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6631973f4502938ccfc75fe8b9d0a3259080d82d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1638239011,
+        "narHash": "sha256-AjhmbT4UBlJWqxY0ea8a6GU2C2HdKUREkG43oRr3TZg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "dfinity-sdk": "dfinity-sdk",
+        "flake-utils": "flake-utils",
+        "mozillapkgs": "mozillapkgs",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,112 @@
+{
+  inputs = {
+    dfinity-sdk = {
+      url = "github:paulyoung/nixpkgs-dfinity-sdk";
+      flake = false;
+    };
+    flake-utils.url = "github:numtide/flake-utils";
+    mozillapkgs = {
+      url = "github:mozilla/nixpkgs-mozilla";
+      flake = false;
+    };
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.url = "github:nixos/nixpkgs/21.11";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    dfinity-sdk,
+    flake-utils,
+    mozillapkgs,
+    naersk,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            (final: prev: (import dfinity-sdk) final prev)
+          ];
+        };
+
+        # Get a specific rust version
+        mozilla = pkgs.callPackage (mozillapkgs + "/package-set.nix") {};
+        rust = (mozilla.rustChannelOf {
+          # Something depends on proc-macro2, which requires at least this version
+          # See https://github.com/dtolnay/proc-macro2/issues/299
+          channel = "stable";
+          version = "1.54.0";
+          sha256 = "NL+YHnOj1++1O7CAaQLijwAxKJW9SnHg8qsiOJ1m0Kk=";
+          # sha256 = pkgs.lib.fakeSha256;
+        }).rust.override {
+          extensions = [
+            "clippy-preview"
+            # "miri-preview"
+            # "rls-preview"
+            # "rust-analyzer-preview"
+            "rustfmt-preview"
+            # "llvm-tools-preview"
+            # "rust-analysis"
+            # "rust-std"
+            # "rustc-dev"
+            # "rustc-docs"
+            "rust-src"
+          ];
+          targets = [
+            "wasm32-unknown-unknown"
+          ];
+        };
+
+        # Override the version used in naersk
+        naersk-lib = naersk.lib."${system}".override {
+          cargo = rust;
+          rustc = rust;
+        };
+
+        dfinitySdk = (pkgs.dfinity-sdk {
+          acceptLicenseAgreement = true;
+          sdkSystem =
+            if system == "aarch64-darwin"
+            then "x86_64-darwin"
+            else system;
+        })."0.8.4";
+      in
+        rec {
+          # `nix build`
+
+          packages.boa = naersk-lib.buildPackage rec {
+            pname = "boa";
+            root = ./.;
+            buildInputs = [] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+            ];
+            cargoBuildOptions = x: x ++ [
+              "--package" pname
+              "--target" "wasm32-unknown-unknown"
+            ];
+            cargoTestOptions = x: x ++ [
+              "--package" pname
+              "--target" "wasm32-unknown-unknown"
+            ];
+            compressTarget = false;
+            copyBins = false;
+            copyTarget = true;
+          };
+
+          defaultPackage = packages.boa;
+
+          # `nix develop`
+          devShell = pkgs.mkShell {
+            buildInputs = [
+              dfinitySdk
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              pkgs.libiconv
+            ];
+
+            # supply the specific rust version
+            nativeBuildInputs = [ rust ];
+          };
+        }
+    );
+}


### PR DESCRIPTION
```
Installing canisters...
Creating UI canister on the local network.
The UI canister on the "local" network is "ryjl3-tyaaa-aaaaa-aaaba-cai"
Installing code for canister boa, with canister_id rrkah-fqaaa-aaaaa-aaaaq-cai
Deployed canisters.
Pauls-MacBook-Pro:main py$ dfx canister call boa rand_bytes
(
  "Random bytes via JS callback: 168,89,66,151,67,122,10,172,227,14,41,204,242,77,111,169,191,34,81,234,197,72,143,90,217,176,131,131,158,104,207,107",
)
```